### PR TITLE
Fixes Sequella's Rake tasks with adhearsion 2.5.2

### DIFF
--- a/lib/sequella/plugin.rb
+++ b/lib/sequella/plugin.rb
@@ -26,16 +26,14 @@ module Sequella
     tasks do
       namespace :sequella do
         desc "Run Sequel migrations"
-        task :migrate => :environment do
-          Service.start Adhearsion.config[:sequella]
+        task :migrate do
           Sequel.extension :migration
           Sequel::Migrator.run Sequella::Service.connection, File.join(Adhearsion.root, 'db', 'migrations'), :use_transactions => true
           puts "Successfully migrated database"
         end
 
         desc "Drop all tables in the database"
-        task :clean => :environment do
-          Service.start Adhearsion.config[:sequella]
+        task :clean do
           Service.connection.tables.each { |t| Service.connection.drop_table t }
           logger.info "Successfully dropped all tables in the database"
         end


### PR DESCRIPTION
With the change in initialization of plugins in Adhearsion 2.5.2, the rake tasks weren't loading the correct config settings.
